### PR TITLE
Fix #11 Fixed that makes configuration scripts work the Windows properly even if changed the system locale

### DIFF
--- a/scripts/compile-dotnet-assemblies.bat
+++ b/scripts/compile-dotnet-assemblies.bat
@@ -1,17 +1,13 @@
 ::http://support.microsoft.com/kb/2570538
 ::http://robrelyea.wordpress.com/2007/07/13/may-be-helpful-ngen-exe-executequeueditems/
 
-if "%PROCESSOR_ARCHITECTURE%"=="AMD64" goto 64BIT
+%windir%\Microsoft.NET\Framework\v4.0.30319\Ngen.exe update /force /queue > NUL
+%windir%\Microsoft.NET\Framework\v4.0.30319\Ngen.exe executequeueditems > NUL
 
-%windir%\microsoft.net\framework\v4.0.30319\ngen.exe update /force /queue > NUL
-%windir%\microsoft.net\framework\v4.0.30319\ngen.exe executequeueditems > NUL
-
-exit 0
+if NOT "%PROCESSOR_ARCHITECTURE%"=="AMD64" exit 0
 
 :64BIT
-%windir%\microsoft.net\framework\v4.0.30319\ngen.exe update /force /queue > NUL
-%windir%\microsoft.net\framework64\v4.0.30319\ngen.exe update /force /queue > NUL
-%windir%\microsoft.net\framework\v4.0.30319\ngen.exe executequeueditems > NUL
-%windir%\microsoft.net\framework64\v4.0.30319\ngen.exe executequeueditems > NUL
+%windir%\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update /force /queue > NUL
+%windir%\Microsoft.NET\Framework64\v4.0.30319\ngen.exe executequeueditems > NUL
 
 exit 0

--- a/scripts/dis-updates.bat
+++ b/scripts/dis-updates.bat
@@ -1,20 +1,38 @@
-rem http://www.windows-commandline.com/disable-automatic-updates-command-line/
-reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update" /v AUOptions /t REG_DWORD /d 1 /f
+REM http://www.windows-commandline.com/disable-automatic-updates-command-line/
 
-rem remove optional WSUS server settings
-reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" /f
+REM --------------------------------------------------------
+REM  Disable WIndows Update
+REM --------------------------------------------------------
+REM  - AUOptions:
+REM     1: Keep my computer up to date is disabled in Automatic Updates.
+REM     2: Notify of download and installation.
+REM     3: Automatically download and notify of installation.
+REM     4: Automatically download and scheduled installation.
+REM --------------------------------------------------------
 
-rem even harder, disable windows update service
-rem sc config wuauserv start= disabled
-rem net stop wuauserv
-set logfile=C:\Windows\Temp\win-updates.log
+REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update" /v AUOptions /t REG_DWORD /d 1 /f
 
-if exist %logfile% (
-  echo Show Windows Updates log file %logfile%
-  dir %logfile%
-  type %logfile%
-  rem output of type command is not fully shown in packer/ssh session, so try PowerShell
-  rem but it will hang if log file is about 22 KByte
-  rem powershell -command "Get-Content %logfile%"
-  echo End of Windows Updates log file %logfile%
+REM --------------------------------------------------------
+REM   Remove optional WSUS server settings
+REM --------------------------------------------------------
+
+REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" > nul 2>&1
+IF %ERRORLEVEL% == 0 (
+  REG DELETE "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" /f
+)
+
+
+REM Even harder, disable windows update service
+REM SC CONFIG WUAUSERV Start=Disabled
+REM NET STOP WUAUSERV
+SET logfile=C:\Windows\Temp\Win-Updates.log
+
+IF EXIST %logfile% (
+  ECHO Show Windows Updates log file %logfile%
+  DIR %logfile%
+  TYPE %logfile%
+  REM output of type command is not fully shown in packer/ssh session, so try PowerShell
+  REM but it will hang if log file is about 22 KByte
+  REM powershell -command "Get-Content %logfile%"
+  ECHO End of Windows Updates log file %logfile%
 )

--- a/scripts/disable-winrm.ps1
+++ b/scripts/disable-winrm.ps1
@@ -5,4 +5,4 @@ if ($winrmService.Status -eq "Running"){
     Disable-PSRemoting -Force
 }
 Stop-Service winrm
-Set-Service -Name winrm -StartupType Disabled
+Set-Service -Name WinRM -StartupType Disabled

--- a/scripts/enable-rdp.bat
+++ b/scripts/enable-rdp.bat
@@ -1,2 +1,2 @@
 netsh advfirewall firewall add rule name="Open Port 3389" dir=in action=allow protocol=TCP localport=3389
-reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server" /v fDenyTSConnections /t REG_DWORD /d 0 /f
+REG add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server" /v fDenyTSConnections /t REG_DWORD /d 0 /f

--- a/scripts/enable-winrm.ps1
+++ b/scripts/enable-winrm.ps1
@@ -13,5 +13,5 @@ winrm set winrm/config/client/auth '@{Basic="true"}'
 winrm set winrm/config/listener?Address=*+Transport=HTTP '@{Port="5985"}'
 netsh advfirewall firewall set rule group="Windows Remote Administration" new enable=yes
 netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" new enable=yes action=allow
-Set-Service winrm -startuptype "auto"
-Restart-Service winrm
+Set-Service WinRM -StartupType "auto"
+Restart-Service WinRM

--- a/scripts/fixnetwork.ps1
+++ b/scripts/fixnetwork.ps1
@@ -10,14 +10,14 @@
 if([environment]::OSVersion.version.Major -lt 6) { return }
 
 # You cannot change the network location if you are joined to a domain, so abort
-if(1,3,4,5 -contains (Get-WmiObject win32_computersystem).DomainRole) { return }
+if(1,3,4,5 -contains (Get-WmiObject Win32_ComputerSystem).DomainRole) { return }
 
 # Get network connections
 $networkListManager = [Activator]::CreateInstance([Type]::GetTypeFromCLSID([Guid]"{DCB00C01-570F-4A9B-8D69-199FDBA5723B}"))
 $connections = $networkListManager.GetNetworkConnections()
 
 $connections |foreach {
-	Write-Host $_.GetNetwork().GetName()"category was previously set to"$_.GetNetwork().GetCategory()
+	Write-Host $_.GetNetwork().GetName()" category was previously set to "$_.GetNetwork().GetCategory()
 	$_.GetNetwork().SetCategory(1)
-	Write-Host $_.GetNetwork().GetName()"changed to category"$_.GetNetwork().GetCategory()
+	Write-Host $_.GetNetwork().GetName()" changed to category "$_.GetNetwork().GetCategory()
 }

--- a/scripts/pin-powershell.bat
+++ b/scripts/pin-powershell.bat
@@ -1,4 +1,0 @@
-rem https://connect.microsoft.com/PowerShell/feedback/details/1609288/pin-to-taskbar-no-longer-working-in-windows-10
-copy "A:\WindowsPowerShell.lnk" "%TEMP%\Windows PowerShell.lnk"
-A:\PinTo10.exe /PTFOL01:'%TEMP%' /PTFILE01:'Windows PowerShell.lnk'
-exit /b 0

--- a/scripts/set-powerplan.ps1
+++ b/scripts/set-powerplan.ps1
@@ -1,20 +1,22 @@
-Try {
-  Write-Output "Set power plan to high performance"
 
-  $HighPerf = powercfg -l | %{if($_.contains("High performance")) {$_.split()[3]}}
+Set-Variable -Name POWER_PLAN_GUID_HIGH_PERF -Value "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c" -Option Constant
 
-  # $HighPerf cannot be $null, we try activate this power profile with powercfg
-  # 
-  if ($HighPerf -eq $null)
-  {
-    throw "Error: HighPerf is null"
+try {
+  Write-Output "Set power plan to High-Performance '$POWER_PLAN_GUID_HIGH_PERF'"
+  if ((POWERCFG /LIST | Where({ $_.Contains($POWER_PLAN_GUID_HIGH_PERF) })).Count -le 0) {
+    throw "Error: Power management plan 'High-Performance' does not exists"
   }
 
-  $CurrPlan = $(powercfg -getactivescheme).split()[3]
+  POWERCFG /S $POWER_PLAN_GUID_HIGH_PERF
+  if ($LASTEXITCODE -ne 0) {
+    throw "Error: Failed to configure power plan to '$POWER_PLAN_GUID_HIGH_PERF'"
+  }
 
-  if ($CurrPlan -ne $HighPerf) {powercfg -setactive $HighPerf}
+  Write-Output "Power plan High-Perfomance '$POWER_PLAN_GUID_HIGH_PERF' was successfully activated"
 
-} Catch {
-  Write-Warning -Message "Unable to set power plan to high performance"
+} catch {
+  Write-Warning -Message "Unable to set power plan to High-Perfomance '$POWER_PLAN_GUID_HIGH_PERF'"
   Write-Warning $Error[0]
 }
+
+

--- a/scripts/set-winrm-automatic.bat
+++ b/scripts/set-winrm-automatic.bat
@@ -1,2 +1,2 @@
-echo Set WinRM start type to auto
-sc config winrm start= auto
+ECHO Set WinRM start type to auto
+SC config WinRM Start=Auto

--- a/scripts/uac-enable.bat
+++ b/scripts/uac-enable.bat
@@ -1,1 +1,1 @@
-reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /f /v EnableLUA /t REG_DWORD /d 1
+REG add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /f /v EnableLUA /t REG_DWORD /d 1


### PR DESCRIPTION
Fixed that makes configuration scripts work the Windows properly even if changed the system locale.
- The power plan setting
- Disabling the windows update
