### PR TITLE
Close #10 Added 'vagrant-cloud' post-processor to upload box

### DIFF
--- a/windows10.json
+++ b/windows10.json
@@ -36,12 +36,22 @@
     }
   ],
   "post-processors": [
-    {
-      "keep_input_artifact": false,
-      "output": "windows10_{{.Provider}}.box",
-      "type": "vagrant",
-      "vagrantfile_template": "vagrantfile-windows10.template"
-    }
+    [
+      {
+        "type": "vagrant",
+        "keep_input_artifact": false,
+        "output": "windows10_{{.Provider}}.box",
+        "vagrantfile_template": "vagrantfile-windows10.template"
+      },
+      {
+        "type": "vagrant-cloud",
+        "box_tag": "{{user `box_tag`}}",
+        "access_token": "{{user `cloud_token`}}",
+        "version": "{{user `version`}}",
+        "version_description": "{{user `version_description`}}",
+        "no_release" : "{{user `no_release`}}"
+      }
+    ]
   ],
   "provisioners": [
     {
@@ -87,6 +97,11 @@
      "switch_name": "Default Switch",
     "headless": "false",
     "restart_timeout": "5m",
-    "winrm_timeout": "6h"
+    "winrm_timeout": "6h",
+    "cloud_token": "{{env `VAGRANT_CLOUD_TOKEN`}}",
+    "box_tag": "ymasuda/windows10",
+    "version": "{{isotime \"20060102\"}}.0.0",
+    "version_description ": "Windows10 Vagrant images updated to {{isotime \"2006-01-02\"}}.",
+    "no_release": "false"
   }
 }


### PR DESCRIPTION
Added 'vagrant-cloud' post-processor to upload box.
Security token to access to Vagrant Cloud would be taken from environment variable 'VAGRANT_CLOUD_TOKEN' by default, and it also can be passed with a build command argument as a user variable.

Decided to employ built date as major version.

Also possible to specify version number and version description  with a build command argument.
If you pass a user variable 'no_release', it would not upload the box.

Find the box uploaded today on the vagrant cloud page
https://app.vagrantup.com/ymasuda/boxes/windows10/versions/20191005.0.0