### PR TITLE
close #16 Changed 'install-wix311.ps1' to that it accepts also 3010 as successful exit code.

### DIFF
--- a/scripts/install-wix311.ps1
+++ b/scripts/install-wix311.ps1
@@ -7,11 +7,18 @@ function EnsureNetFramework3Installed
       Write-Host "Enabling .NET Framework 3.1..." -ForegroundColor Cyan
       $Arguments = @("/c", "DISM.exe /Quiet /Online /Enable-Feature /FeatureName:NetFX3 /All")
       $process = Start-Process -FilePath "cmd.exe" -ArgumentList $Arguments -Wait -PassThru
-      if ($process.ExitCode -ne 0)
+      if ($exitCode -eq 0 -or $exitCode -eq 3010)
       {
-        exit $process.ExitCode
+          Write-Host ".NET Framework 3.1 enabled." -ForegroundColor Cyan
+          return $exitCode
       }
-      Write-Host ".NET Framework 3.1 enabled." -ForegroundColor Cyan
+      else
+      {
+          Write-Host -Object "Non zero exit code returned by the installation process : $exitCode."
+          # this wont work because of log size limitation in extension manager
+          # Get-Content $customLogFilePath | Write-Host
+          exit $exitCode
+      }
   }
 }
 

--- a/windows10_vs2019.json
+++ b/windows10_vs2019.json
@@ -30,6 +30,7 @@
         "./scripts/install-wix311.ps1",
         "./scripts/install-wix311-vs2019.ps1"
       ],
+      "valid_exit_codes": [0,3010],
       "elevated_user":     "vagrant",
       "elevated_password": "vagrant"
     },


### PR DESCRIPTION
Changed 'install-wix311.ps1' to that it accepts also 3010 as successful exit code.
In addition, added 3010 to valid exit code in the provisioner section in the windows10_vs2019.json .